### PR TITLE
Bump platformVersion to the latest update

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The following additional features have been added to the IDE:
 1. Check if your Intellij IDEA version and edition matches the properties set in `gradle.properties` file:
 ```
 platformType = IC
-platformVersion = 2021.2
+platformVersion = 2021.3.2
 ```
 For the Intellij IDEA Community edition you need to keep `IC` as is, for the Ultimate edition it should become `IU`.
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,7 +12,7 @@ pluginUntilBuild = 213.*
 
 # IntelliJ Platform Properties -> https://github.com/JetBrains/gradle-intellij-plugin#intellij-platform-properties
 platformType = IC
-platformVersion = 2021.2
+platformVersion = 2021.3.2
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22


### PR DESCRIPTION
Initially I tried to use `platformVersion = 2021.3` and it failed to build. Bumped the version in the readme to the latest.