### PR TITLE
Fix headless checkbox not showing up

### DIFF
--- a/src/main/kotlin/com/codingmates/ghidra/intellij/ide/runConfiguration/GhidraLauncherConfigurationEditor.kt
+++ b/src/main/kotlin/com/codingmates/ghidra/intellij/ide/runConfiguration/GhidraLauncherConfigurationEditor.kt
@@ -30,7 +30,7 @@ class GhidraLauncherConfigurationEditor(project: Project) : SettingsEditor<Ghidr
             argEditor(CCFlags.growX)
         }
         row("Use headless") {
-            isHeadless
+            isHeadless(CCFlags.growX)
         }
     }
 


### PR DESCRIPTION
Tested on Intellij CE 2022.1.3. Without this fix, I see the following:
![Screen Shot 2022-06-27 at 2 07 11 PM](https://user-images.githubusercontent.com/816362/176007658-18adfbbf-7f2a-411a-84b1-30644d067bb4.png)
and with the fix, it looks like
![Screen Shot 2022-06-27 at 2 06 30 PM](https://user-images.githubusercontent.com/816362/176007682-1799f4e4-7164-445e-a2d2-5ab20c56f0d0.png)

