### PR TITLE
Import arguments for non-headless configurations.

### DIFF
--- a/src/main/kotlin/com/codingmates/ghidra/intellij/ide/runConfiguration/GhidraLauncherCommandLineState.kt
+++ b/src/main/kotlin/com/codingmates/ghidra/intellij/ide/runConfiguration/GhidraLauncherCommandLineState.kt
@@ -24,10 +24,10 @@ class GhidraLauncherCommandLineState(
         javaParameters.mainClass = "ghidra.GhidraLauncher"
         if (configuration.getHeadless()) {
             javaParameters.programParametersList.add("ghidra.app.util.headless.AnalyzeHeadless")
-            javaParameters.programParametersList.addParametersString(configuration.getArgs())
         } else {
             javaParameters.programParametersList.add("ghidra.GhidraRun")
         }
+        javaParameters.programParametersList.addParametersString(configuration.getArgs())
         javaParameters.vmParametersList.addAll(GHIDRA_CLI_OPTS)
         JavaParametersUtil.configureProject(
             project,


### PR DESCRIPTION
Run arguments for non-headless configurations were ignored. This PR addresses said limitation.