### PR TITLE
Support latest 2022.3 IntelliJ

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,3 +1,4 @@
+import org.jetbrains.changelog.Changelog.OutputType
 import org.jetbrains.changelog.markdownToHTML
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
@@ -7,11 +8,11 @@ plugins {
     // Java support
     id("java")
     // Kotlin support
-    id("org.jetbrains.kotlin.jvm") version "1.7.10"
+    id("org.jetbrains.kotlin.jvm") version "1.7.22"
     // Gradle IntelliJ Plugin
-    id("org.jetbrains.intellij") version "1.7.0"
+    id("org.jetbrains.intellij") version "1.10.0"
     // Gradle Changelog Plugin
-    id("org.jetbrains.changelog") version "1.3.1"
+    id("org.jetbrains.changelog") version "2.0.0"
     // Gradle Qodana Plugin
     id("org.jetbrains.qodana") version "0.1.13"
 }
@@ -85,8 +86,9 @@ tasks {
         // Get the latest available change notes from the changelog file
         changeNotes.set(provider {
             changelog.run {
-                getOrNull(properties("pluginVersion")) ?: getLatest()
-            }.toHTML()
+                val item = getOrNull(properties("pluginVersion")) ?: getLatest()
+                changelog.renderItem(item, OutputType.HTML)
+            }
         })
     }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,23 +3,23 @@
 
 pluginGroup = com.codingmates.ghidra
 pluginName = IntelliJ Ghidra
-pluginVersion = 0.4.0
+pluginVersion = 0.4.1
 
 # See https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 # for insight into build numbers and IntelliJ Platform versions.
-pluginSinceBuild = 203
-pluginUntilBuild = 222.*
+pluginSinceBuild = 223
+pluginUntilBuild = 223.*
 
 # IntelliJ Platform Properties -> https://github.com/JetBrains/gradle-intellij-plugin#intellij-platform-properties
 platformType = IC
-platformVersion = 2022.2
+platformVersion = 2022.3
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.intellij.java, com.jetbrains.php:203.4449.22
 platformPlugins = com.intellij.java
 
 # Java language level used to compile sources and to generate the files for - Java 11 is required since 2020.3
-javaVersion = 11
+javaVersion = 17
 
 # Gradle Releases -> https://github.com/gradle/gradle/releases
 gradleVersion = 7.5

--- a/src/main/kotlin/com/codingmates/ghidra/intellij/ide/facet/GhidraFacet.kt
+++ b/src/main/kotlin/com/codingmates/ghidra/intellij/ide/facet/GhidraFacet.kt
@@ -9,7 +9,6 @@ import com.intellij.openapi.module.Module
 import com.intellij.openapi.module.ModuleManager
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.roots.*
-import com.intellij.openapi.roots.libraries.Library
 import com.intellij.util.messages.MessageBusConnection
 
 
@@ -68,7 +67,7 @@ class GhidraFacet(
         var modelChanged = false
 
         try {
-            val libraries = ModifiableModelsProvider.SERVICE.getInstance().libraryTableModifiableModel
+            val libraries = ModifiableModelsProvider.getInstance().libraryTableModifiableModel
             val library = libraries.getLibraryByName(GHIDRA_LIBRARY_NAME)
 
             if (library != null) {
@@ -90,7 +89,7 @@ class GhidraFacet(
 
         try {
             val installation = configuration.loadGhidraInstallation()
-            val libraries = ModifiableModelsProvider.SERVICE.getInstance().libraryTableModifiableModel
+            val libraries = ModifiableModelsProvider.getInstance().libraryTableModifiableModel
 
             var library = libraries.getLibraryByName(GHIDRA_LIBRARY_NAME)
             if (library == null) {


### PR DESCRIPTION
Hello,

I've updated the build configuration files to support IntelliJ 2022.3. This version now uses [Java 17](https://blog.jetbrains.com/platform/2022/08/intellij-project-migrates-to-java-17/) as its runtime, therefore I had to limit the backwards compatibility to only this major version. A method of the changelog plugin was [deprecated](https://github.com/JetBrains/gradle-changelog-plugin/blob/main/CHANGELOG.md#200---2022-10-28) in version 2.0, so I've replaced it.

There seems to be a problem with the plugin development environment as IntelliJ doesn't properly import the required sources, so all Kotlin files are full of errors. Nevertheless, the plugin builds without any errors.

Edit: This problem seems to be known, see [intellij-platform-plugin-template#320](https://github.com/JetBrains/intellij-platform-plugin-template/issues/320).

Best wishes,
Lukas
